### PR TITLE
Fix for memory leak in RKObjectRequestOperation

### DIFF
--- a/Code/Network/RKHTTPRequestOperation.h
+++ b/Code/Network/RKHTTPRequestOperation.h
@@ -130,4 +130,20 @@
 - (void)setCompletionBlockWithSuccess:(void (^)(RKHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(RKHTTPRequestOperation *operation, NSError *error))failure;
 
+
+
+///--------------------
+/// @name Notifications
+///--------------------
+
+/**
+ Posted when an HTTP request operation begin executing.
+ */
+extern NSString *const RKHTTPRequestOperationDidStartNotification;
+
+/**
+ Posted when an HTTP request operation finishes.
+ */
+extern NSString *const RKHTTPRequestOperationDidFinishNotification;
+
 @end

--- a/Code/Network/RKHTTPRequestOperation.m
+++ b/Code/Network/RKHTTPRequestOperation.m
@@ -106,11 +106,6 @@ const NSMutableSet *acceptableContentTypes;
     
     if ([self isExecuting]) {
         // Pause
-        // Cancel the connection on the thread it runs on to prevent race conditions
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[NSNotificationCenter defaultCenter] postNotificationName:RKHTTPRequestOperationDidFinishNotification object:self];
-        });
     }
     
     self.state = RKOperationPausedState;

--- a/Code/Network/RKObjectRequestOperation.h
+++ b/Code/Network/RKObjectRequestOperation.h
@@ -228,16 +228,6 @@ extern NSString *const RKObjectRequestOperationDidStartNotification;
 extern NSString *const RKObjectRequestOperationDidFinishNotification;
 
 /**
- Posted when an HTTP request operation begin executing.
- */
-extern NSString *const RKHTTPRequestOperationDidStartNotification;
-
-/**
- Posted when an HTTP request operation finishes.
- */
-extern NSString *const RKHTTPRequestOperationDidFinishNotification;
-
-/**
  The key for an `NSDate` object specifying the time at which object mapping started for object request operation. Available in the user info dictionary of an `RKObjectRequestOperationDidFinishNotification`
  */
 extern NSString *const RKObjectRequestOperationMappingDidStartUserInfoKey;

--- a/Code/Network/RKObjectRequestOperation.h
+++ b/Code/Network/RKObjectRequestOperation.h
@@ -228,6 +228,16 @@ extern NSString *const RKObjectRequestOperationDidStartNotification;
 extern NSString *const RKObjectRequestOperationDidFinishNotification;
 
 /**
+ Posted when an HTTP request operation begin executing.
+ */
+extern NSString *const RKHTTPRequestOperationDidStartNotification;
+
+/**
+ Posted when an HTTP request operation finishes.
+ */
+extern NSString *const RKHTTPRequestOperationDidFinishNotification;
+
+/**
  The key for an `NSDate` object specifying the time at which object mapping started for object request operation. Available in the user info dictionary of an `RKObjectRequestOperationDidFinishNotification`
  */
 extern NSString *const RKObjectRequestOperationMappingDidStartUserInfoKey;

--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -104,11 +104,11 @@ static NSString *RKLogTruncateString(NSString *string)
                                                    object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(HTTPOperationDidStart:)
-                                                     name:RKObjectRequestOperationDidStartNotification
+                                                     name:RKHTTPRequestOperationDidStartNotification
                                                    object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(HTTPOperationDidFinish:)
-                                                     name:RKObjectRequestOperationDidFinishNotification
+                                                     name:RKHTTPRequestOperationDidFinishNotification
                                                    object:nil];
     }
     
@@ -230,6 +230,8 @@ static void *RKOperationFinishDate = &RKOperationFinishDate;
 
 NSString *const RKObjectRequestOperationDidStartNotification = @"RKObjectRequestOperationDidStartNotification";
 NSString *const RKObjectRequestOperationDidFinishNotification = @"RKObjectRequestOperationDidFinishNotification";
+NSString *const RKHTTPRequestOperationDidStartNotification = @"RKHTTPRequestOperationDidStartNotification";
+NSString *const RKHTTPRequestOperationDidFinishNotification = @"RKHTTPRequestOperationDidFinishNotification";
 NSString *const RKResponseHasBeenMappedCacheUserInfoKey = @"RKResponseHasBeenMapped";
 NSString *const RKObjectRequestOperationMappingDidStartUserInfoKey = @"mappingStartedAt";
 NSString *const RKObjectRequestOperationMappingDidFinishUserInfoKey = @"mappingFinishedAt";
@@ -343,6 +345,7 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
         self.stateMachine = [[RKOperationStateMachine alloc] initWithOperation:self dispatchQueue:[[self class] dispatchQueue]];
         [self.stateMachine setExecutionBlock:^{
             [[NSNotificationCenter defaultCenter] postNotificationName:RKObjectRequestOperationDidStartNotification object:weakSelf];
+            [[NSNotificationCenter defaultCenter] postNotificationName:RKHTTPRequestOperationDidStartNotification object:weakSelf.HTTPRequestOperation];
             RKIncrementNetworkActivityIndicator();
             if (weakSelf.isCancelled) {
                 [weakSelf.stateMachine finish];
@@ -353,6 +356,7 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
         [self.stateMachine setFinalizationBlock:^{
             [weakSelf willFinish];
             RKDecrementNetworkAcitivityIndicator();
+            [[NSNotificationCenter defaultCenter] postNotificationName:RKHTTPRequestOperationDidFinishNotification object:weakSelf.HTTPRequestOperation];
             [[NSNotificationCenter defaultCenter] postNotificationName:RKObjectRequestOperationDidFinishNotification object:weakSelf userInfo:@{ RKObjectRequestOperationMappingDidStartUserInfoKey: weakSelf.mappingDidStartDate ?: [NSNull null], RKObjectRequestOperationMappingDidFinishUserInfoKey: weakSelf.mappingDidFinishDate ?: [NSNull null] }];
         }];
         [self.stateMachine setCancellationBlock:^{

--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -230,8 +230,6 @@ static void *RKOperationFinishDate = &RKOperationFinishDate;
 
 NSString *const RKObjectRequestOperationDidStartNotification = @"RKObjectRequestOperationDidStartNotification";
 NSString *const RKObjectRequestOperationDidFinishNotification = @"RKObjectRequestOperationDidFinishNotification";
-NSString *const RKHTTPRequestOperationDidStartNotification = @"RKHTTPRequestOperationDidStartNotification";
-NSString *const RKHTTPRequestOperationDidFinishNotification = @"RKHTTPRequestOperationDidFinishNotification";
 NSString *const RKResponseHasBeenMappedCacheUserInfoKey = @"RKResponseHasBeenMapped";
 NSString *const RKObjectRequestOperationMappingDidStartUserInfoKey = @"mappingStartedAt";
 NSString *const RKObjectRequestOperationMappingDidFinishUserInfoKey = @"mappingFinishedAt";
@@ -345,7 +343,6 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
         self.stateMachine = [[RKOperationStateMachine alloc] initWithOperation:self dispatchQueue:[[self class] dispatchQueue]];
         [self.stateMachine setExecutionBlock:^{
             [[NSNotificationCenter defaultCenter] postNotificationName:RKObjectRequestOperationDidStartNotification object:weakSelf];
-            [[NSNotificationCenter defaultCenter] postNotificationName:RKHTTPRequestOperationDidStartNotification object:weakSelf.HTTPRequestOperation];
             RKIncrementNetworkActivityIndicator();
             if (weakSelf.isCancelled) {
                 [weakSelf.stateMachine finish];
@@ -356,7 +353,6 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
         [self.stateMachine setFinalizationBlock:^{
             [weakSelf willFinish];
             RKDecrementNetworkAcitivityIndicator();
-            [[NSNotificationCenter defaultCenter] postNotificationName:RKHTTPRequestOperationDidFinishNotification object:weakSelf.HTTPRequestOperation];
             [[NSNotificationCenter defaultCenter] postNotificationName:RKObjectRequestOperationDidFinishNotification object:weakSelf userInfo:@{ RKObjectRequestOperationMappingDidStartUserInfoKey: weakSelf.mappingDidStartDate ?: [NSNull null], RKObjectRequestOperationMappingDidFinishUserInfoKey: weakSelf.mappingDidFinishDate ?: [NSNull null] }];
         }];
         [self.stateMachine setCancellationBlock:^{


### PR DESCRIPTION
Hi @oligriffiths,

During the last few days I've finally found the time to test the current state of your development branch. It appears to be quite stable.

However, I came across a retain cycle issue which prevents any _RKObjectRequestOperation_ to be deallocated. After investigating a few hours, I might have found the root cause.

The following methods get called if _RKObjectRequestOperationDidStartNotification_ or _RKObjectRequestOperationDidFinishNotification_ notifications are received:

``` objective-c
- (void)objectRequestOperationDidStart:(NSNotification *)notification
{
    ...
    objc_setAssociatedObject(objectRequestOperation.HTTPRequestOperation, RKParentObjectRequestOperation, objectRequestOperation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
}

- (void)HTTPOperationDidFinish:(NSNotification *)notification 
{
    RKHTTPRequestOperation *operation = [notification object];    
    if (![operation isKindOfClass:[RKHTTPRequestOperation class]]) return;

    RKObjectRequestOperation *parentOperation = objc_getAssociatedObject(operation, RKParentObjectRequestOperation);
    objc_setAssociatedObject(operation, RKParentObjectRequestOperation, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
    ...
} 
```

As you can see, every RKHTTPRequestOperation dynamically holds a strong reference to the parent RKObjectRequestOperation during the time of execution. 

``` objective-c
@implementation RKObjectRequestOperation
...
- (instancetype)initWithHTTPRequestOperation:(RKHTTPRequestOperation *)requestOperation responseDescriptors:(NSArray *)responseDescriptors {
    ...
    [self.stateMachine setFinalizationBlock:^{
        ...
        [[NSNotificationCenter defaultCenter] postNotificationName:RKObjectRequestOperationDidFinishNotification object:weakSelf userInfo:@{ RKObjectRequestOperationMappingDidStartUserInfoKey: weakSelf.mappingDidStartDate ?: [NSNull null], RKObjectRequestOperationMappingDidFinishUserInfoKey: weakSelf.mappingDidFinishDate ?: [NSNull null] }];
    }];
}
...
```

We never break the retain cycle though, because _HTTPOperationDidFinish:_ expects a _RKHTTPRequestOperation_ (but receives a _RKObjectRequestOperation_) and returns prematurely.

My pull request provides a (quick) fix, but I am not that familiar with the code and I might have overlooked something. What would be your preferred way to fix this issue?

-Mathias

/cc @tinora @ptclarke @segiddins
