### PR TITLE
Only attempts mime serialization if response contains `MIMEType`

### DIFF
--- a/Code/Network/RKHTTPClient.m
+++ b/Code/Network/RKHTTPClient.m
@@ -202,7 +202,7 @@ defaultHeaders = _defaultHeaders;
         id responseObject;
         if(self.responseSerializerClass){
             responseObject = [self.responseSerializerClass objectFromData:data error:&error];
-        }else{
+        }else if (response.MIMEType) {
             responseObject = [RKMIMETypeSerialization objectFromData:data MIMEType:response.MIMEType error:&error];
         }
         


### PR DESCRIPTION
If a 204 response occurs with no content, then no `MIMEType` is provided with the response.

`RKMIMETypeSerialization` raises an exception if a nil `MIMEType` is passed.
